### PR TITLE
Replace mustard accent color with teal

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,6 +10,36 @@
     <meta name="description" content="{{ site.description }}">
     <link rel="stylesheet"
           href="https://cdn.jsdelivr.net/gh/forestryio/ubuild-blocks@1.0.0/dist/css/ubuild.css"/>
+    <style>
+      .button.primary {
+        background-color: #0C8186;
+        color: #fff;
+      }
+      .button.primary:hover {
+        background-color: #0a6e72;
+      }
+      .button.secondary {
+        border-color: #0C8186;
+        color: #0C8186;
+      }
+      .block-hero-1,
+      .block-hero-2 {
+        --bg: #0C8186;
+      }
+      .block-cta-bar {
+        background: #0C8186;
+      }
+      .block-header-1 .nav-item.active a,
+      .block-header-2 .nav-item.active a {
+        color: #0C8186;
+      }
+      ::selection {
+        background: #a8dfe1;
+      }
+      ::-moz-selection {
+        background: #a8dfe1;
+      }
+    </style>
     <link rel="icon" href="/uploads/linkml-logo_color-no-words.png">
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-2SYBSJVZ23"></script>
     <script>


### PR DESCRIPTION
## Summary
- Overrides the external uBuild theme's mustard accent color (`#ffcb3c`) with teal (`#0C8186`) via inline CSS in `_includes/head.html`
- Covers: primary/secondary buttons, hero sections, CTA bar, active nav links, and text selection highlight
- Adds white text on primary buttons and a darker hover state for better contrast with the new color

## Test plan
- [ ] Verify the site renders with the new teal color on buttons, hero banners, and nav active states
- [ ] Check text readability/contrast on primary buttons and hero sections
- [ ] Confirm hover state on primary buttons works

🤖 Generated with [Claude Code](https://claude.com/claude-code)