### PR TITLE
Add Open Graph meta tags and update meta description

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LinkML – Linked Data Modeling Language</title>
-  <meta name="description" content="A flexible modeling language for authoring schemas in YAML. Generate JSON Schema, RDF, Python, TypeScript, SQL, and 30+ other formats from a single source of truth.">
+  <meta name="description" content="An open framework that simplifies authoring, validating, and sharing data — providing an accessible platform for interdisciplinary collaboration and a reliable way to define and share data semantics.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://linkml.io">
+  <meta property="og:title" content="LinkML – Bring structure to your data.">
+  <meta property="og:description" content="An open framework that simplifies authoring, validating, and sharing data — providing an accessible platform for interdisciplinary collaboration and a reliable way to define and share data semantics.">
+  <meta property="og:image" content="https://linkml.io/uploads/linkml-logo_color.png">
   <link rel="icon" type="image/png" href="uploads/linkml-logo_color-no-words.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">


### PR DESCRIPTION
## Summary

- Updates `<meta name="description">` to match the new hero copy from #26
- Adds full Open Graph tags (`og:title`, `og:description`, `og:url`, `og:image`) so link previews in Slack, iMessage, LinkedIn, etc. show the correct headline and description instead of the old format-focused copy

## Test plan
- [ ] Share the site URL in Slack or iMessage and verify the preview shows "LinkML – Bring structure to your data." with the updated description

🤖 Generated with [Claude Code](https://claude.com/claude-code)